### PR TITLE
Update crunch.io homepage banner

### DIFF
--- a/content/resources/demo-recording.md
+++ b/content/resources/demo-recording.md
@@ -1,15 +1,15 @@
 +++
 date = "2022-9-23T12:20:23-04:00"
 draft = false
-title = "Insights Tech Showcase Brand Tracking"
-about = "See why over 1,000 insights teams and market research firms use Crunch.io to analyze their large-scale tracking studies."
+title = "Taking Tracker Analytics Online"
+about = "Thursday, March 23, 10:00am GMT | 2:00pm EST"
 schedule = ""
-label = "Demo Showcase"
+label = "Case Studies"
 url = "//info.crunch.io/brand-tracking-demo-sep-2022"
 weight = 200
-images = ["https://crunch.io/img/logo-1200x630.png"]
-link = "Watch Now"
+images = ["/img/crunch-webinar-event.svg"]
+link = "Register now"
 series = "main"
-icon = "img/icons/event-icon-blue.svg"
+icon = "img/icons/webinar-icon.svg"
 
 +++

--- a/content/resources/taking-tracker-analytics-online.md
+++ b/content/resources/taking-tracker-analytics-online.md
@@ -1,0 +1,30 @@
++++
+date = "2023-03-23T12:20:23-04:00"
+draft = false
+title = "Taking Tracker Analytics Online"
+about = "See Crunch.io in action presented by Jeff Coombs, President, and Chris Jones, Senior Director of Product."
+label = "Case Studies"
+url = "//info.crunch.io/web-crunch-automation-webinar-march-2023"
+weight = 200
+images = ["https://crunch.io/img/logo-1200x630.png"]
+link = "Register now"
+series = "main"
+icon = "img/icons/webinar-icon.svg"
+
++++
+
+<!-- +++
+date = "2022-9-23T12:20:23-04:00"
+draft = false
+title = "Insights Tech Showcase Brand Tracking"
+about = "See why over 1,000 insights teams and market research firms use Crunch.io to analyze their large-scale tracking studies."
+schedule = ""
+label = "Demo Showcase"
+url = "//info.crunch.io/brand-tracking-demo-sep-2022"
+weight = 200
+images = ["https://crunch.io/img/logo-1200x630.png"]
+link = "Watch Now"
+series = "main"
+icon = "img/icons/event-icon-blue.svg"
+
++++ -->

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,3 +1,3 @@
 <div class="header-banner">
-    <p class="banner-text text-center">New Crunch Dashboards: Bring the speed of scripting to the ease of drag-and-drop | <a class="d-block d-sm-inline" href="https://info.crunch.io/meet-the-new-crunch-dashboards" target="_blank">Watch Now</a></p>
+    <p class="banner-text text-center">Webinar - Case Studies: Taking Tracker Analytics Online | <a class="d-block d-sm-inline" href="https://info.crunch.io/web-crunch-automation-webinar-march-2023" target="_blank">Join us March 23</a></p>
 </div>

--- a/layouts/resources/list.html
+++ b/layouts/resources/list.html
@@ -40,7 +40,7 @@
                               </div>
 
                               <div class="col-md-5 col-sm-5 d-none d-md-block d-lg-block">
-                                    <img src="img/greenbook-event.png" alt="" class="img-fluid">
+                                    <img src="img/crunch-webinar-event.svg" alt="{{ .Title }}" class="img-fluid">
                               </div>
 
                               <!-- <div class="col-md-6 offset-md-1 figure d-none d-md-block d-lg-block"> </div> -->

--- a/static/img/crunch-webinar-event.svg
+++ b/static/img/crunch-webinar-event.svg
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 27.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 565 345" style="enable-background:new 0 0 565 345;" xml:space="preserve">
+<style type="text/css">
+	.st0{clip-path:url(#SVGID_00000164481358965130164440000001904778458778331543_);}
+	.st1{fill:url(#Rectangle_00000009574461847899251220000015235128025480512395_);}
+	.st2{fill:#FFFFFF;}
+	.st3{fill:#F9F9F9;}
+	.st4{fill:none;}
+	.st5{fill:none;stroke:#D6D6D6;stroke-linecap:square;stroke-miterlimit:10;}
+	.st6{fill:none;stroke:#D3D3D3;stroke-linecap:square;stroke-miterlimit:10;}
+	.st7{fill:#D3D3D3;}
+	.st8{fill:#0062A6;}
+	.st9{fill:#107F65;}
+	.st10{fill:#722580;}
+	.st11{fill:#EFEFEF;}
+	.st12{fill:#E5E5E5;}
+	.st13{font-family:'ProximaNova-Bold';}
+	.st14{font-size:12px;}
+	.st15{fill:none;stroke:#FFFFFF;stroke-linecap:square;stroke-miterlimit:10;}
+	.st16{fill:#C5C5C5;}
+	.st17{fill:none;stroke:#FFFFFF;stroke-width:2;stroke-linecap:square;stroke-miterlimit:10;}
+	.st18{fill:none;stroke:#EADBED;stroke-width:2;stroke-miterlimit:10;}
+	.st19{fill:none;stroke:#722580;stroke-width:2;stroke-miterlimit:10;}
+	.st20{fill:none;stroke:#E1E9E9;stroke-width:2;stroke-miterlimit:10;}
+	.st21{fill:none;stroke:#E5E5E5;stroke-miterlimit:10;}
+	.st22{fill:#CCE1EF;}
+	.st23{fill:#EADBED;}
+	.st24{fill:none;stroke:#D3D3D3;stroke-linejoin:round;stroke-miterlimit:10;}
+	.st25{fill:#6D7278;}
+	.st26{font-family:'ProximaNova-Semibold';}
+	.st27{font-size:10px;}
+</style>
+<g>
+	<defs>
+		<rect id="SVGID_1_" width="565" height="345"/>
+	</defs>
+	<clipPath id="SVGID_00000064326225258698293050000006756278336624702901_">
+		<use xlink:href="#SVGID_1_"  style="overflow:visible;"/>
+	</clipPath>
+	<g id="Artboard_3" style="clip-path:url(#SVGID_00000064326225258698293050000006756278336624702901_);">
+		<g id="Group_7" transform="translate(-507)">
+			<g id="Group_10" transform="translate(750.071 43.125)">
+				<g id="Group" transform="translate(0.158)">
+					
+						<linearGradient id="Rectangle_00000062159944194163672560000004680351678632941974_" gradientUnits="userSpaceOnUse" x1="-265.099" y1="521.7191" x2="-266.091" y2="521.558" gradientTransform="matrix(295.24 0 0 -59.537 78578.4453 31086.0195)">
+						<stop  offset="0" style="stop-color:#E6E9EB"/>
+						<stop  offset="1" style="stop-color:#D4D6D9"/>
+					</linearGradient>
+					<path id="Rectangle" style="fill:url(#Rectangle_00000062159944194163672560000004680351678632941974_);" d="M3,0h289.2
+						c1.7,0,3,1.3,3,3v53.5c0,1.7-1.3,3-3,3H3c-1.7,0-3-1.3-3-3V3C0,1.3,1.3,0,3,0z"/>
+					<path id="Rectangle-2" class="st2" d="M0,16.3h295.2l0,0v199.6c0,1.7-1.3,3-3,3H3c-1.7,0-3-1.3-3-3V16.3L0,16.3z"/>
+				</g>
+				<rect id="Rectangle-3" x="72.9" y="31.9" class="st3" width="223" height="187"/>
+				<g id="Group_9" transform="translate(79.773 43.125)">
+					<g id="dashboard-screenshot2" transform="translate(66.503)">
+						<rect id="Rectangle_2" x="0" class="st2" width="147.5" height="126.4"/>
+						<rect id="Mask-5" x="1.9" y="14.5" class="st4" width="141.7" height="106.1"/>
+					</g>
+					<g id="Group_4" transform="translate(0 129.519)">
+						<g id="dashboard-screenshot2_copy_2">
+							<rect id="Rectangle_2-2" x="0" y="0" class="st2" width="213" height="44.4"/>
+							<rect id="Mask-6" x="3.9" y="4.8" class="st4" width="204.3" height="37.6"/>
+						</g>
+						<path id="Line_Copy_6" class="st5" d="M18.3,35.6l195.2-0.4"/>
+						<path id="Line_Copy_6-2" class="st6" d="M139.4,31.3v14.5"/>
+						<path id="Line_Copy_11" class="st6" d="M163.3,31.3v14.5"/>
+						<path id="Line_Copy_12" class="st6" d="M187.3,31.3v14.5"/>
+						<path id="Line_Copy_7" class="st6" d="M114.2,31.3v14.5"/>
+						<path id="Line_Copy_8" class="st6" d="M89.2,31.3v14.5"/>
+						<path id="Line_Copy_9" class="st6" d="M65.4,31.3v14.5"/>
+						<path id="Line_Copy_10" class="st6" d="M40,31.3v14.5"/>
+						<rect id="Rectangle_Copy_4" x="6" y="8.4" class="st7" width="43.7" height="2.8"/>
+					</g>
+				</g>
+				<g id="dashboard-screenshot2_copy" transform="translate(80.089 43.125)">
+					<rect id="Rectangle_2-3" x="-0.2" y="-0.2" class="st2" width="61" height="46"/>
+					<rect id="Mask-7" x="0.5" y="5.2" class="st4" width="58.9" height="38.9"/>
+				</g>
+				<g id="dashboard-screenshot2_copy_3" transform="translate(80.089 96.518)">
+					<rect id="Rectangle_2-4" x="-0.2" y="0.4" class="st2" width="61" height="73"/>
+					<rect id="Mask-8" x="0.5" y="8" class="st4" width="58.9" height="60.3"/>
+				</g>
+				<path id="Line" class="st6" d="M166.2,99.4h129"/>
+				<path id="Line_Copy" class="st6" d="M166.2,117.6h129"/>
+				<path id="Line_Copy_2" class="st6" d="M166.2,135.9h129"/>
+				<path id="Line_Copy_3" class="st6" d="M166.2,155.8h129"/>
+				<rect id="Rectangle-4" x="165.9" y="134.9" class="st8" width="7" height="19"/>
+				<rect id="Rectangle_Copy_5" x="198.9" y="125.9" class="st8" width="6" height="28"/>
+				<rect id="Rectangle_Copy_8" x="231.9" y="135.9" class="st8" width="7" height="18"/>
+				<rect id="Rectangle_Copy_31" x="266.9" y="135.9" class="st8" width="7" height="18"/>
+				<rect id="Rectangle_Copy_3" x="174.9" y="80.9" class="st9" width="6" height="73"/>
+				<rect id="Rectangle_Copy_6" x="206.9" y="112.9" class="st9" width="8" height="43"/>
+				<rect id="Rectangle_Copy_9" x="239.9" y="104.9" class="st9" width="8" height="51"/>
+				<rect id="Rectangle_Copy_33" x="273.9" y="104.9" class="st9" width="6" height="51"/>
+				<rect id="Rectangle_Copy_4-2" x="182.9" y="145.9" class="st10" width="6" height="10"/>
+				<rect id="Rectangle_Copy_7" x="214.9" y="131.9" class="st10" width="6" height="24"/>
+				<rect id="Rectangle_Copy_10" x="248.9" y="112.9" class="st10" width="7" height="43"/>
+				<rect id="Rectangle_Copy_34" x="281.9" y="112.9" class="st10" width="7" height="43"/>
+				<rect id="Rectangle-5" x="152.9" y="50.9" class="st7" width="43" height="4"/>
+				<rect id="Rectangle_Copy_26" x="87.9" y="50.9" class="st7" width="44" height="4"/>
+				<rect id="Rectangle_Copy_27" x="87.9" y="104.9" class="st7" width="44" height="3"/>
+				<rect id="Rectangle_Copy_6-2" x="152.9" y="59.9" class="st7" width="79" height="2"/>
+				<rect id="Rectangle_Copy_28" x="87.9" y="110.9" class="st7" width="50" height="2"/>
+				<rect id="Rectangle_Copy_29" x="85.9" y="118.9" class="st7" width="32" height="2"/>
+				<rect id="Rectangle_Copy_69" x="152.9" y="62.9" class="st7" width="66" height="2"/>
+				<rect id="Rectangle_Copy_70" x="87.9" y="113.9" class="st7" width="40" height="2"/>
+				<rect id="Rectangle_Copy_71" x="85.9" y="122.9" class="st7" width="38" height="1"/>
+				<g id="Group_5" transform="translate(5.134 36.49)">
+					<path id="Rectangle-6" class="st11" d="M0.5,0h60.4c0.3,0,0.5,0.2,0.5,0.5v8.9c0,0.3-0.2,0.5-0.5,0.5H0.5C0.2,9.9,0,9.6,0,9.4
+						V0.5C0,0.2,0.2,0,0.5,0z"/>
+					<path id="Rectangle_Copy_2" class="st11" d="M0.5,15h60.4c0.3,0,0.5,0.2,0.5,0.5v8.9c0,0.3-0.2,0.5-0.5,0.5H0.5
+						c-0.3,0-0.5-0.2-0.5-0.5v-8.9C0,15.2,0.2,15,0.5,15z"/>
+					<rect id="Rectangle-7" x="4.1" y="2.8" class="st7" width="51.6" height="3.6"/>
+					<rect id="Rectangle_Copy_32" x="4.5" y="18.6" class="st7" width="35.8" height="3.6"/>
+				</g>
+				<g id="Group_5_Copy" transform="translate(5.134 66.346)">
+					<path id="Rectangle-8" class="st11" d="M0.5,0h60.4c0.3,0,0.5,0.2,0.5,0.5v8.6c0,0.3-0.2,0.5-0.5,0.5H0.5C0.2,9.6,0,9.4,0,9.1
+						V0.5C0,0.2,0.2,0,0.5,0z"/>
+					<path id="Rectangle_Copy_2-2" class="st11" d="M0.5,15.2h60.4c0.3,0,0.5,0.2,0.5,0.5v8.6c0,0.3-0.2,0.5-0.5,0.5H0.5
+						c-0.3,0-0.5-0.2-0.5-0.5v-8.6C0,15.5,0.2,15.2,0.5,15.2z"/>
+					<rect id="Rectangle-9" x="4.1" y="3.2" class="st7" width="51.6" height="3.2"/>
+					<rect id="Rectangle_Copy_32-2" x="4.5" y="18.5" class="st7" width="35.8" height="3.2"/>
+				</g>
+				<rect id="Rectangle-10" x="-0.1" y="16.9" class="st12" width="296" height="15"/>
+				<rect id="Rectangle-11" x="6.9" y="19.9" class="st3" width="47" height="12"/>
+				<rect id="Rectangle_Copy_40" x="53.9" y="19.9" class="st7" width="49" height="12"/>
+				<rect id="Rectangle_Copy_48" x="102.9" y="19.9" class="st7" width="48" height="12"/>
+				<rect id="Rectangle_Copy_56" x="150.9" y="19.9" class="st7" width="48" height="12"/>
+				<text transform="matrix(1 0 0 1 87.929 72.875)" class="st8 st13 st14">38%</text>
+				<g id="Group_8" transform="translate(110.893 131.231)">
+					<path id="Combined_Shape" class="st10" d="M0.1,32.6H0v-9.9h0.2c3.5,0.1,6.4-2.7,6.5-6.2c0-1.7-0.7-3.2-1.9-4.4
+						c-1.2-1.2-2.9-1.8-4.5-1.8v-10c4.4,0,8.6,1.7,11.8,4.7c6.3,6,6.6,15.9,0.7,22.2c-0.2,0.2-0.4,0.5-0.7,0.7
+						C8.8,30.9,4.5,32.6,0.1,32.6z"/>
+					<path id="Combined_Shape-2" class="st8" d="M33.3,32.6c-4.4,0-8.7-1.7-11.9-4.7c-1.5-1.4-2.7-3.1-3.6-5v-2.2h10.8
+						c1.3,1.3,3,2.1,4.8,2.1c3.5,0.1,6.4-2.7,6.5-6.2c0-1.7-0.7-3.2-1.9-4.4c-1.2-1.2-2.8-1.8-4.5-1.8v-10c4.4,0,8.6,1.7,11.8,4.7
+						c6.3,6,6.6,15.9,0.7,22.2c-0.2,0.2-0.4,0.5-0.7,0.7C42,30.9,37.7,32.6,33.3,32.6z"/>
+					<path id="Line_2" class="st15" d="M0.6,0v32.8"/>
+				</g>
+				<circle id="Oval" class="st16" cx="8.9" cy="7.9" r="2"/>
+				<ellipse id="Oval_Copy" class="st16" cx="15.9" cy="8.4" rx="3" ry="2.5"/>
+				<circle id="Oval_Copy_2" class="st16" cx="22.9" cy="7.9" r="2"/>
+			</g>
+			<g id="Group_25_Copy_2" transform="translate(526.213 111.13)">
+				<path id="Line_3" class="st17" d="M0.3,71.6L0,159.2"/>
+				<path id="Line_3-2" class="st17" d="M124.2,159.6L0.1,160.9"/>
+				<path id="Path_5" class="st18" d="M10.1,122.8l12.9,29.8L50,104.1l29.7,38.5l44.7-71.3"/>
+				<path id="Path_5_Copy_2" class="st19" d="M10.1,116.5L22.9,131L49,109.5L79.8,124l44.7-31.2"/>
+				<path id="Path_5_Copy" class="st20" d="M5.1,128.6l15.9,10.8l26.9-21l31,11l45.6-48.1"/>
+				<g id="Group_17_Copy" transform="translate(41.09 6.951)">
+					<g id="Rectangle-12" transform="translate(-0.303 -0.08)">
+						<path class="st2" d="M1,0h153c0.6,0,1,0.4,1,1v79c0,0.6-0.4,1-1,1H1c-0.6,0-1-0.4-1-1V1C0,0.4,0.4,0,1,0z"/>
+						<path class="st21" d="M1,0.5h153c0.3,0,0.5,0.2,0.5,0.5v79c0,0.3-0.2,0.5-0.5,0.5H1c-0.3,0-0.5-0.2-0.5-0.5V1
+							C0.5,0.7,0.7,0.5,1,0.5z"/>
+					</g>
+				</g>
+				<g id="Group_5-2" transform="translate(56.492 16.587)">
+					<path id="Rectangle-13" class="st7" d="M38.3,13.9h10.2c0.3,0,0.5,0.2,0.5,0.5V19c0,0.3-0.2,0.5-0.5,0.5H38.3
+						c-0.3,0-0.5-0.2-0.5-0.5v-4.6C37.8,14.2,38,13.9,38.3,13.9z"/>
+					<path id="Rectangle_Copy" class="st7" d="M74,13.9h10.2c0.3,0,0.5,0.2,0.5,0.5V19c0,0.3-0.2,0.5-0.5,0.5H74
+						c-0.3,0-0.5-0.2-0.5-0.5v-4.6C73.5,14.2,73.8,13.9,74,13.9z"/>
+					<path id="Rectangle_Copy_2-3" class="st7" d="M109.8,13.9H120c0.3,0,0.5,0.2,0.5,0.5V19c0,0.3-0.2,0.5-0.5,0.5h-10.2
+						c-0.3,0-0.5-0.2-0.5-0.5v-4.6C109.2,14.2,109.5,13.9,109.8,13.9z"/>
+					<path id="Rectangle_Copy_3-2" class="st7" d="M38.3,28.6h10.2c0.3,0,0.5,0.2,0.5,0.5v4.6c0,0.3-0.2,0.5-0.5,0.5H38.3
+						c-0.3,0-0.5-0.2-0.5-0.5v-4.6C37.8,28.8,38,28.6,38.3,28.6z"/>
+					<path id="Rectangle_Copy_11" class="st7" d="M74,28.6h10.2c0.3,0,0.5,0.2,0.5,0.5v4.6c0,0.3-0.2,0.5-0.5,0.5H74
+						c-0.3,0-0.5-0.2-0.5-0.5v-4.6C73.5,28.8,73.8,28.6,74,28.6z"/>
+					<path id="Rectangle_Copy_13" class="st7" d="M109.8,28.6H120c0.3,0,0.5,0.2,0.5,0.5v4.6c0,0.3-0.2,0.5-0.5,0.5h-10.2
+						c-0.3,0-0.5-0.2-0.5-0.5v-4.6C109.2,28.8,109.5,28.6,109.8,28.6z"/>
+					<path id="Rectangle_Copy_9-2" class="st7" d="M38.3,41.8h10.2c0.3,0,0.5,0.2,0.5,0.5v4.6c0,0.3-0.2,0.5-0.5,0.5H38.3
+						c-0.3,0-0.5-0.2-0.5-0.5v-4.6C37.8,42.1,38,41.8,38.3,41.8z"/>
+					<path id="Rectangle_Copy_12" class="st7" d="M74,41.8h10.2c0.3,0,0.5,0.2,0.5,0.5v4.6c0,0.3-0.2,0.5-0.5,0.5H74
+						c-0.3,0-0.5-0.2-0.5-0.5v-4.6C73.5,42.1,73.8,41.8,74,41.8z"/>
+					<path id="Rectangle_Copy_38" class="st7" d="M109.8,41.8H120c0.3,0,0.5,0.2,0.5,0.5v4.6c0,0.3-0.2,0.5-0.5,0.5h-10.2
+						c-0.3,0-0.5-0.2-0.5-0.5v-4.6C109.2,42.1,109.5,41.8,109.8,41.8z"/>
+					<path id="Rectangle_Copy_10-2" class="st7" d="M38.3,55.8h10.2c0.3,0,0.5,0.2,0.5,0.5v4.6c0,0.3-0.2,0.5-0.5,0.5H38.3
+						c-0.3,0-0.5-0.2-0.5-0.5v-4.6C37.8,56,38,55.8,38.3,55.8z"/>
+					<path id="Rectangle_Copy_37" class="st7" d="M74,55.8h10.2c0.3,0,0.5,0.2,0.5,0.5v4.6c0,0.3-0.2,0.5-0.5,0.5H74
+						c-0.3,0-0.5-0.2-0.5-0.5v-4.6C73.5,56,73.8,55.8,74,55.8z"/>
+					<path id="Rectangle_Copy_39" class="st7" d="M109.8,55.8H120c0.3,0,0.5,0.2,0.5,0.5v4.6c0,0.3-0.2,0.5-0.5,0.5h-10.2
+						c-0.3,0-0.5-0.2-0.5-0.5v-4.6C109.2,56,109.5,55.8,109.8,55.8z"/>
+					<path id="Rectangle_Copy_4-3" class="st9" d="M31.3,0h23.5c0.3,0,0.5,0.2,0.5,0.5v4.6c0,0.3-0.2,0.5-0.5,0.5H31.3
+						c-0.3,0-0.5-0.2-0.5-0.5V0.5C30.8,0.2,31,0,31.3,0z"/>
+					<path id="Rectangle_Copy_7-2" class="st9" d="M0.5,13.9H24c0.3,0,0.5,0.2,0.5,0.5V19c0,0.3-0.2,0.5-0.5,0.5H0.5
+						C0.2,19.5,0,19.3,0,19v-4.6C0,14.2,0.2,13.9,0.5,13.9z"/>
+					<path id="Rectangle_Copy_8-2" class="st9" d="M0.5,28.6H24c0.3,0,0.5,0.2,0.5,0.5v4.6c0,0.3-0.2,0.5-0.5,0.5H0.5
+						c-0.3,0-0.5-0.2-0.5-0.5v-4.6C0,28.8,0.2,28.6,0.5,28.6z"/>
+					<path id="Rectangle_Copy_35" class="st9" d="M0.5,41.8H24c0.3,0,0.5,0.2,0.5,0.5v4.6c0,0.3-0.2,0.5-0.5,0.5H0.5
+						c-0.3,0-0.5-0.2-0.5-0.5v-4.6C0,42.1,0.2,41.8,0.5,41.8z"/>
+					<path id="Rectangle_Copy_36" class="st9" d="M0.5,55.8H24c0.3,0,0.5,0.2,0.5,0.5v4.6c0,0.3-0.2,0.5-0.5,0.5H0.5
+						c-0.3,0-0.5-0.2-0.5-0.5v-4.6C0,56,0.2,55.8,0.5,55.8z"/>
+					<path id="Rectangle_Copy_5-2" class="st9" d="M66.3,0h23.5c0.3,0,0.5,0.2,0.5,0.5v4.6c0,0.3-0.2,0.5-0.5,0.5H66.3
+						c-0.3,0-0.5-0.2-0.5-0.5V0.5C65.8,0.2,66.1,0,66.3,0z"/>
+					<path id="Rectangle_Copy_6-3" class="st9" d="M102,0h23.5c0.3,0,0.5,0.2,0.5,0.5v4.6c0,0.3-0.2,0.5-0.5,0.5H102
+						c-0.3,0-0.5-0.2-0.5-0.5V0.5C101.5,0.2,101.8,0,102,0z"/>
+				</g>
+				<rect id="Rectangle_Copy_17" x="172.8" y="52.9" class="st22" width="68" height="9"/>
+				<rect id="Rectangle_Copy_20" x="172.8" y="97.9" class="st22" width="45" height="9"/>
+				<rect id="Rectangle_Copy_23" x="172.8" y="142.9" class="st22" width="72" height="8"/>
+				<rect id="Rectangle_Copy_18" x="172.8" y="63.9" class="st10" width="81" height="8"/>
+				<rect id="Rectangle_Copy_21" x="172.8" y="107.9" class="st10" width="53" height="8"/>
+				<rect id="Rectangle_Copy_24" x="172.8" y="150.9" class="st10" width="61" height="8"/>
+				<rect id="Rectangle_Copy_19" x="172.8" y="71.9" class="st23" width="61" height="8"/>
+				<rect id="Rectangle_Copy_22" x="172.8" y="115.9" class="st23" width="61" height="8"/>
+				<rect id="Rectangle_Copy_25" x="172.8" y="160.9" class="st23" width="81" height="8"/>
+				<path id="Line_3-3" class="st17" d="M172.4,53.5l0.1,115.6"/>
+				<g id="Group_8-2" transform="translate(1.757 0)">
+					<g id="Group_17_Copy_2">
+						<g id="Rectangle-14">
+							<path class="st2" d="M2,0h45.8c1.1,0,2,0.9,2,2v21.7c0,1.1-0.9,2-2,2H2c-1.1,0-2-0.9-2-2V2C0,0.9,0.9,0,2,0z"/>
+							<path class="st24" d="M2,0.5h45.8c0.8,0,1.5,0.7,1.5,1.5v21.7c0,0.8-0.7,1.5-1.5,1.5H2c-0.8,0-1.5-0.7-1.5-1.5V2
+								C0.5,1.2,1.2,0.5,2,0.5z"/>
+						</g>
+					</g>
+					<g id="Group_7-2" transform="translate(0 19.937)">
+						<path id="Fill_1" class="st2" d="M24.8,19.1L24.8,19.1c-1,1.8-3,3.7-5.2,3.8c-0.1,0-0.1,0-0.2,0h-5.1h-0.6h-0.6
+							c-1,0-2-0.1-2.9-0.3c-1.1-0.4-2.1-1.1-2.9-2c-0.2-0.2-0.4-0.4-0.7-0.6l-5.1-4.9c-1.1-1-1.2-2.8-0.1-3.9c0,0,0.1-0.1,0.1-0.1
+							L1.7,11c1.2-1.1,3-1.1,4.2,0c0.1,0.1,0.3,0.1,0.4,0.1c0.1-0.1,0.2-0.2,0.2-0.3V3c0.1-1.3,1.1-2.2,2.4-2.2c1,0,1.9,0.8,2.1,1.8
+							v1.7c0,0,0,0.1,0,0.1l0,0.1v0.2c0,0.2,0.2,0.4,0.4,0.4c0.2,0,0.4-0.2,0.4-0.4V3c0-0.1,0-0.3,0-0.4V2.2C11.9,0.9,13-0.1,14.2,0
+							c1.2,0.1,2.1,1,2.2,2.2v2.9c0,0.1,0,0.2,0.1,0.3c0.1,0.2,0.3,0.3,0.5,0.2c0.1-0.1,0.2-0.2,0.2-0.3V2.9c0-1.1,0.9-1.9,2-1.9
+							c1,0,1.8,0.8,1.9,1.9v1.4c0,0.2,0,0.3-0.1,0.5v1.1c0,0.1,0.1,0.3,0.2,0.3c0.2,0.1,0.4,0.1,0.5,0c0.1-0.1,0.1-0.2,0.1-0.2
+							l0-1.5c0.2-0.7,0.9-1.2,1.6-1.2c0.9,0,1.6,0.7,1.7,1.6v5.9c0,0,0,0.1,0,0.1v5.5c0,0.2,0,0.3,0,0.5
+							C25.3,17.6,25.1,18.4,24.8,19.1"/>
+						<path id="Fill_1-2" class="st25" d="M13,23.7c-1,0-2.1-0.1-3.1-0.3c-1.2-0.4-2.4-1.2-3.2-2.2c-0.2-0.2-0.4-0.4-0.6-0.6l-5-4.7
+							c-1.3-1.2-1.4-3.3-0.2-4.6C0.9,11.2,1,11.1,1.1,11l0.1-0.1c0.7-0.7,1.6-1,2.6-1c0.6,0,1.1,0.1,1.6,0.3l0.3,0.2V3.6
+							c0.1-1.6,1.4-2.9,3-2.8c0.8,0,1.6,0.3,2.1,0.8l0.2,0.2l0.2-0.3c0.8-1.5,2.7-2,4.2-1.2c0.5,0.3,0.9,0.7,1.2,1.3L16.9,2l0.2-0.2
+							C17.6,1.3,18.3,1,19,1c1.3,0,2.5,0.9,2.7,2.3l0,0.4L22,3.5c0.4-0.2,0.8-0.3,1.2-0.3c1.3,0,2.3,1,2.4,2.2v4.4c0,0,0,0.1,0,0.1
+							v6.5c0,0.2,0,0.3,0,0.5h0.2l-0.2,0c0.1,0.9-0.1,1.8-0.5,2.6c-1,1.8-3.1,3.9-5.8,4.1h-0.1h-0.1L13,23.7z M3.8,10.6
+							c-0.8,0-1.5,0.3-2.1,0.8l-0.1,0.1c-1.1,1-1.1,2.6-0.2,3.7c0.1,0.1,0.1,0.1,0.2,0.2l5,4.7c0.2,0.2,0.4,0.4,0.6,0.6
+							c0.8,0.9,1.7,1.6,2.8,2C11.1,22.9,12,23,13,23h0.6h0.6h5c0,0,0.1,0,0.1,0h0.1c2.2-0.1,4.1-2,5.1-3.7c0.3-0.7,0.5-1.5,0.4-2.3
+							c0-0.2,0-0.3,0-0.5v-5.3c0,0,0-0.1,0-0.1V5.4c0-0.9-0.8-1.6-1.6-1.5c-0.7,0-1.4,0.5-1.6,1.2l0,1.4c0,0.2-0.2,0.4-0.4,0.4
+							c-0.1,0-0.2,0-0.3-0.1c-0.1-0.1-0.2-0.2-0.2-0.3v-1c0-0.2,0-0.3,0.1-0.5V3.5c-0.1-1.1-1-1.9-2-1.8c-1,0.1-1.7,0.8-1.8,1.8v2.2
+							c0,0.2-0.2,0.4-0.4,0.3c-0.1,0-0.3-0.1-0.4-0.2c-0.1-0.1-0.1-0.2-0.1-0.3V2.8c-0.1-1.2-1.2-2.2-2.4-2.1c-1.1,0.1-2,1-2.1,2.1
+							v0.4c0,0.1,0,0.3,0,0.4v1.7c0,0.2-0.2,0.4-0.4,0.4c-0.2,0-0.3-0.2-0.4-0.4V5.1L11,5c0,0,0-0.1,0-0.1V3.2
+							c-0.2-1-1.2-1.8-2.2-1.7c-1.2,0-2.2,0.9-2.3,2.1v7.6c0,0.1-0.1,0.3-0.2,0.3c0,0-0.1,0-0.1,0c-0.1,0-0.2,0-0.3-0.1
+							C5.3,10.9,4.6,10.6,3.8,10.6z"/>
+					</g>
+					<text transform="matrix(1 0 0 1 -10.452 14.254)" class="st25 st26 st27">Age</text>
+				</g>
+			</g>
+		</g>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
Update crunch.io homepage banner to : Webinar - Case Studies: Taking Tracker Analytics Online | Join us March 23 -->
https://trello.com/c/5BqDNEx3
